### PR TITLE
Fix relative to absolute url conversion

### DIFF
--- a/internal/stringutil/stringutil.go
+++ b/internal/stringutil/stringutil.go
@@ -28,7 +28,6 @@ package stringutil
 
 import (
 	nurl "net/url"
-	"path"
 	"regexp"
 	"strings"
 	"unicode"
@@ -101,11 +100,6 @@ func CreateAbsoluteURL(url string, base *nurl.URL) string {
 	}
 
 	// Otherwise, resolve against base URI.
-	// Normalize URL first.
-	if !strings.HasPrefix(url, "/") {
-		url = path.Join(base.Path, url)
-	}
-
 	tmp, err = nurl.Parse(url)
 	if err != nil {
 		return url

--- a/internal/stringutil/stringutil_test.go
+++ b/internal/stringutil/stringutil_test.go
@@ -58,6 +58,7 @@ func Test_StringUtil_CreateAbsoluteURL(t *testing.T) {
 	relURL7 := "www.google.com"
 	relURL8 := "http//www.google.com"
 	relURL9 := "../hello/relative"
+	relURL10 := "image.png"
 
 	absURL1 := "#here"
 	absURL2 := "http://example.com/test/123"
@@ -66,10 +67,12 @@ func Test_StringUtil_CreateAbsoluteURL(t *testing.T) {
 	absURL5 := "https://www.google.com"
 	absURL6 := "ftp://ftp.server.com"
 	absURL7 := "http://example.com/page/www.google.com"
-	absURL8 := "http://example.com/page/http/www.google.com"
+	absURL8 := "http://example.com/page/http//www.google.com"
 	absURL9 := "http://example.com/hello/relative"
+	absURL10 := "http://example.com/page/image.png"
 
 	baseURL, _ := nurl.ParseRequestURI("http://example.com/page/")
+	baseURL2, _ := nurl.ParseRequestURI("http://example.com/page/doc.html")
 	assert.Equal(t, absURL1, stringutil.CreateAbsoluteURL(relURL1, baseURL))
 	assert.Equal(t, absURL2, stringutil.CreateAbsoluteURL(relURL2, baseURL))
 	assert.Equal(t, absURL3, stringutil.CreateAbsoluteURL(relURL3, baseURL))
@@ -79,4 +82,5 @@ func Test_StringUtil_CreateAbsoluteURL(t *testing.T) {
 	assert.Equal(t, absURL7, stringutil.CreateAbsoluteURL(relURL7, baseURL))
 	assert.Equal(t, absURL8, stringutil.CreateAbsoluteURL(relURL8, baseURL))
 	assert.Equal(t, absURL9, stringutil.CreateAbsoluteURL(relURL9, baseURL))
+	assert.Equal(t, absURL10, stringutil.CreateAbsoluteURL(relURL10, baseURL2))
 }


### PR DESCRIPTION
This PR removes the custom path joining for path relative URLs and relies on the `url.ResolveReference()` method to convert a path relative URL to an absolute URL.

In the current `main` branch, all images from [this](https://martinfowler.com/articles/patterns-of-distributed-systems/paxos.html) page are broken after parsing.

With a root URL of https://martinfowler.com/articles/patterns-of-distributed-systems/paxos.html, the image `<img src="mfpaxos-initial-requests.png">` is currently converted to:

```
https://martinfowler.com/articles/patterns-of-distributed-systems/paxos.html/mfpaxos-initial-requests.png
```

when it should be converted to:

```
https://martinfowler.com/articles/patterns-of-distributed-systems/mfpaxos-initial-requests.png
```